### PR TITLE
Add WiFiScanResults

### DIFF
--- a/io.edgehog.devicemanager.WiFiAP.json
+++ b/io.edgehog.devicemanager.WiFiAP.json
@@ -1,0 +1,43 @@
+{
+  "interface_name": "io.edgehog.devicemanager.WiFiScanResults",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "device",
+  "aggregation": "object",
+  "mappings": [
+    {
+      "endpoint": "/ap/channel",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "The channel over which the client is communicating with the access point.",
+      "doc": "The channel represents one of the ranges into which the reference frequency is divided and it's identified by an integer number in the range 1 - 165, depending on the frequency itself and the region."
+    },
+    {
+      "endpoint": "/ap/essid",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "Extended Service Set Identification of the current AP, empty string if the AP is hidden."
+    },
+    {
+      "endpoint": "/ap/macAddress",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "Lower case mac address string formatted like `de:ad:be:ff:11:22`."
+    },
+    {
+      "endpoint": "/ap/rssi",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "The current signal strength measured in dBm."
+    }
+  ]
+}


### PR DESCRIPTION
Add `io.edgehog.devicemanager.WiFiScanResults` interface for publishing a WiFi AP close to the device.
APs found during the same scan will be sent in consecutive messages but with the same `explicit_timestamp`.

This information can be both used for diagnostic and geolocation purposes.

Closes #7 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>