### PR TITLE
Add ApplianceInfo

### DIFF
--- a/io.edgehog.devicemanager.ApplianceInfo.json
+++ b/io.edgehog.devicemanager.ApplianceInfo.json
@@ -1,0 +1,20 @@
+{
+  "interface_name": "io.edgehog.devicemanager.ApplianceInfo",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "description": "Information about the appliance",
+  "mappings": [
+    {
+      "endpoint": "/serialNumber",
+      "type": "string",
+      "description": "The serial number of the appliance"
+    },
+    {
+      "endpoint": "/partNumber",
+      "type": "string",
+      "description": "The part number of the appliance"
+    }
+  ]
+}


### PR DESCRIPTION
Add `io.edgehog.devicemanager.ApplianceInfo` interface for publishing data relative to the client's appliance in which the device is installed.

Closes #4 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>