### PR TITLE
Add OTA interfaces

### DIFF
--- a/io.edgehog.devicemanager.OTARequest.json
+++ b/io.edgehog.devicemanager.OTARequest.json
@@ -1,0 +1,26 @@
+{
+    "interface_name": "io.edgehog.devicemanager.OTARequest",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "server",
+    "aggregation": "object",
+    "mappings": [
+        {
+            "endpoint": "/request/url",
+            "type": "string",
+            "reliability": "guaranteed",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 31556952,
+            "description": "File URL"
+        },
+        {
+            "endpoint": "/request/uuid",
+            "type": "string",
+            "reliability": "guaranteed",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 31556952,
+            "description": "Request identifier"
+        }
+    ]
+}

--- a/io.edgehog.devicemanager.OTAResponse.json
+++ b/io.edgehog.devicemanager.OTAResponse.json
@@ -1,0 +1,33 @@
+{
+    "interface_name": "io.edgehog.devicemanager.OTAResponse",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "aggregation": "object",
+    "mappings": [
+        {
+            "endpoint": "/response/uuid",
+            "type": "string",
+            "reliability": "guaranteed",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 31556952,
+            "description": "Request identifier"
+        },
+        {
+            "endpoint": "/response/status",
+            "type": "string",
+            "reliability": "guaranteed",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 31556952,
+            "description": "Possible values: [ InProgress | Error | Done ]"
+        },
+        {
+            "endpoint": "/response/statusCode",
+            "type": "string",
+            "reliability": "guaranteed",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 31556952
+        }
+    ]
+}


### PR DESCRIPTION
- Add `io.edgehog.devicemanager.OTARequest.json` interface for receiving new ota from server...
- Add `io.edgehog.devicemanager.OTARespone.json` interface for publishing the ota state...

Closes #11.