### PR TITLE
Add Storage Datastream Interface

### DIFF
--- a/io.edgehog.devicemanager.Storage.json
+++ b/io.edgehog.devicemanager.Storage.json
@@ -1,0 +1,26 @@
+{
+  "interface_name": "io.edgehog.devicemanager.Storage",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "device",
+  "aggregation": "object",
+  "mappings": [
+    {
+      "endpoint": "/storage/%{label}/totalBytes",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Total storage size in bytes",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/storage/%{label}/freeBytes",
+      "type": "longinteger",
+      "explicit_timestamp": true,
+      "description": "Available storage bytes",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    }
+  ]
+}


### PR DESCRIPTION
Add `io.edgehog.devicemanager.Storage` interface for publishing device
storage usage telemetry.
