### PR TITLE
Add Battery Datastream Interface

### DIFF
--- a/io.edgehog.devicemanager.BatteryStatus.json
+++ b/io.edgehog.devicemanager.BatteryStatus.json
@@ -1,0 +1,34 @@
+{
+  "interface_name": "io.edgehog.devicemanager.BatteryStatus",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "device",
+  "aggregation": "object",
+  "mappings": [
+    {
+      "endpoint": "/%{battery_slot}/levelPercentage",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Battery level estimated percentage [0.0%-100.0%]",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/%{battery_slot}/levelAbsoluteError",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Battery level measurement absolute error [0.0-100.0]",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/%{battery_slot}/status",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Battery status string, any of: Charging, Discharging, Idle, EitherIdleOrCharging, Failure, Removed, Unknown",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    }
+  ]
+}


### PR DESCRIPTION
Introduce an interface for battery status and charge level telemetry.
This new interface supports telemetry for the following variables,
for each available battery/battey slot:

- `status`: a status string such as "Charging"
- `levelPercentage`: charge level in [0.0%-100.0%] range, such as 89.0%
- `levelAbsoluteError`: the level measurement absolute error in
[0.0-100.0] range

"EitherIdleOrCharging" status is avaiable when it is not possible to distinguish
between "Idle" and "Charging".

Last but not least an invalid `levelPercentage` will have 100.0 as
`levelAbsoluteError`.

Closes #10 