### PR TITLE
Add OSInfo

### DIFF
--- a/io.edgehog.devicemanager.OSInfo.json
+++ b/io.edgehog.devicemanager.OSInfo.json
@@ -1,0 +1,19 @@
+{
+  "interface_name": "io.edgehog.devicemanager.OSInfo",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "mappings": [
+    {
+      "endpoint": "/osName",
+      "type": "string",
+      "description": "Name of the Operating System"
+    },
+    {
+      "endpoint": "/osVersion",
+      "type": "string",
+      "description": "Version of the Operating System"
+    }
+  ]
+}


### PR DESCRIPTION
Add OSInfo interface to communicate to the server the current name and version of the operating system on which the device manager is running.

Closes #22 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>