### PR TITLE
Add OS Bundle interface

### DIFF
--- a/io.edgehog.devicemanager.OSBundle.json
+++ b/io.edgehog.devicemanager.OSBundle.json
@@ -1,0 +1,29 @@
+{
+  "interface_name": "io.edgehog.devicemanager.OSBundle",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "mappings": [
+    {
+      "endpoint": "/fingerprint",
+      "type": "string",
+      "description": "OS bundle release identification code"
+    },
+    {
+      "endpoint": "/name",
+      "type": "string",
+      "description": "Name of the bundle"
+    },
+    {
+      "endpoint": "/version",
+      "type": "string",
+      "description": "Version of the bundle"
+    },
+    {
+      "endpoint": "/buildId",
+      "type": "string",
+      "description": "Human readable build identifier. Examples are `[date][time]` or `[date]-[time]-[git-commit]`"
+    }
+  ]
+}


### PR DESCRIPTION
Add `io.edgehog.devicemanager.OSBundle`interface to communicate info relative to client specific OS/Firmware.

Closes #27 