### PR TITLE
Add GSM/LTE info interfaces

### DIFF
--- a/io.edgehog.devicemanager.CellularConnectionProperties.json
+++ b/io.edgehog.devicemanager.CellularConnectionProperties.json
@@ -1,0 +1,27 @@
+{
+  "interface_name": "io.edgehog.devicemanager.CellularConnectionProperties",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "mappings": [
+    {
+      "endpoint": "/%{id}/apn",
+      "type": "string",
+      "description": "Operator apn address.",
+      "allow_unset": true
+    },
+    {
+      "endpoint": "/%{id}/imei",
+      "type": "string",
+      "description": "The modem IMEI code of the device.",
+      "allow_unset": true
+    },
+    {
+      "endpoint": "/%{id}/imsi",
+      "type": "string",
+      "description": "The SIM IMSI code of the device.",
+      "allow_unset": true
+    }
+  ]
+}

--- a/io.edgehog.devicemanager.CellularConnectionStatus.json
+++ b/io.edgehog.devicemanager.CellularConnectionStatus.json
@@ -1,0 +1,74 @@
+{
+  "interface_name": "io.edgehog.devicemanager.CellularConnectionStatus",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "device",
+  "aggregation": "object",
+  "mappings": [
+    {
+      "endpoint": "/%{id}/carrier",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "Connectivity carrier operator name."
+    },
+    {
+      "endpoint": "/%{id}/cellId",
+      "type": "longinteger",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "The Cell ID in hexadecimal format, either 16 bit for 2G or 28 bit for 3G or 4G."
+    },
+    {
+      "endpoint": "/%{id}/mobileCountryCode",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "The mobile country code (MCC) for the device's home network. Valid range: 0–999."
+    },
+    {
+      "endpoint": "/%{id}/mobileNetworkCode",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "The Mobile Network Code for the device's home network. This is the MNC for GSM, WCDMA, LTE and NR. CDMA uses the System ID (SID). Valid range for MNC: 0–999. Valid range for SID: 0–32767."
+    },
+    {
+      "endpoint": "/%{id}/localAreaCode",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "Two byte location area code in hexadecimal format."
+    },
+    {
+      "endpoint": "/%{id}/registrationStatus",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "GSM/LTE registration status. Possible values: [NotRegistered, Registered, SearchingOperator, RegistrationDenied, Unknown, RegisteredRoaming]"
+    },
+    {
+      "endpoint": "/%{id}/rssi",
+      "type": "double",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "Signal strenght of the device in dBm."
+    },
+    {
+      "endpoint": "/%{id}/technology",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000,
+      "explicit_timestamp": true,
+      "description": "Access Technology. Possible values [GSM, GSMCompact, UTRAN, GSMwEGPRS, UTRANwHSDPA, UTRANwHSUPA, UTRANwHSDPAandHSUPA, EUTRAN]"
+    }
+  ]
+}


### PR DESCRIPTION
Add `io.edgehog.devicemanager.CellularConnectionProperties` interface to communicate hardware info relative to the GSM/LTE modem and SIM and the apn configuration.

Add `io.edgehog.devicemanager.CellularConnectionStatus` interface to report connection status data such as signal strenght and carrier operator name.

Close #17 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>