### PR TITLE
Rename OSBundle to BaseImage

### DIFF
--- a/io.edgehog.devicemanager.BaseImage.json
+++ b/io.edgehog.devicemanager.BaseImage.json
@@ -1,5 +1,5 @@
 {
-  "interface_name": "io.edgehog.devicemanager.OSBundle",
+  "interface_name": "io.edgehog.devicemanager.BaseImage",
   "version_major": 0,
   "version_minor": 1,
   "type": "properties",


### PR DESCRIPTION
Rename `io.edgehog.devicemanager.OSBundle` to `io.edgehog.devicemanager.BaseImage`, BaseImage is more generic and doesn't tie the bundle to the OS concept.

Close #32 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>