### PR TITLE
Rename ApplianceInfo to SystemInfo

### DIFF
--- a/io.edgehog.devicemanager.SystemInfo.json
+++ b/io.edgehog.devicemanager.SystemInfo.json
@@ -1,20 +1,20 @@
 {
-  "interface_name": "io.edgehog.devicemanager.ApplianceInfo",
+  "interface_name": "io.edgehog.devicemanager.SystemInfo",
   "version_major": 0,
   "version_minor": 1,
   "type": "properties",
   "ownership": "device",
-  "description": "Information about the appliance",
+  "description": "Information about the system",
   "mappings": [
     {
       "endpoint": "/serialNumber",
       "type": "string",
-      "description": "The serial number of the appliance"
+      "description": "The serial number of the system"
     },
     {
       "endpoint": "/partNumber",
       "type": "string",
-      "description": "The part number of the appliance"
+      "description": "The part number of the system"
     }
   ]
 }


### PR DESCRIPTION
Rename `io.edgehog.devicemanager.ApplianceInfo` to `io.edgehog.devicemanager.SystemInfo`. The Appliance concept has been renamed to System inside Edgehog.

Close #33 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>