### PR TITLE
Add Geolocation interface

### DIFF
--- a/io.edgehog.devicemanager.Geolocation.json
+++ b/io.edgehog.devicemanager.Geolocation.json
@@ -1,0 +1,54 @@
+{
+  "interface_name": "io.edgehog.devicemanager.Geolocation",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "device",
+  "description": "Generic Geolocation sampled data.",
+  "doc": "Geolocation allows geolocation sensors to stream location data, such as GPS data. Values availability depends on what sensors are present on devices and what measurement systems are in use. The id represents a unique identifier for an individual sensor.",
+  "mappings": [
+    {
+      "endpoint": "/%{id}/latitude",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled latitude value."
+    },
+    {
+      "endpoint": "/%{id}/longitude",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled longitude value."
+    },
+    {
+      "endpoint": "/%{id}/altitude",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled altitude value."
+    },
+    {
+      "endpoint": "/%{id}/accuracy",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled accuracy of the latitude and longitude properties."
+    },
+    {
+      "endpoint": "/%{id}/altitudeAccuracy",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled accuracy of the altitude property."
+    },
+    {
+      "endpoint": "/%{id}/heading",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled value representing the direction towards which the device is facing."
+    },
+    {
+      "endpoint": "/%{id}/speed",
+      "type": "double",
+      "explicit_timestamp": true,
+      "description": "Sampled value representing the velocity of the device."
+    }
+  ]
+}


### PR DESCRIPTION
Add `io.edgehog.devicemanager.Geolocation` interface for communicating device positioning (longitude, latitude and accuracy).

Close #40 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>