### PR TITLE
Add QoS and TTL in Commands, Geolocation, LedBehavior and OTA

### DIFF
--- a/io.edgehog.devicemanager.Commands.json
+++ b/io.edgehog.devicemanager.Commands.json
@@ -8,6 +8,7 @@
         {
             "endpoint": "/request",
             "type": "string",
+            "reliability": "unique",
             "explicit_timestamp": true,
             "description": "Command request. Possible values  ['Reboot']"
         }

--- a/io.edgehog.devicemanager.Geolocation.json
+++ b/io.edgehog.devicemanager.Geolocation.json
@@ -12,43 +12,57 @@
       "endpoint": "/%{id}/latitude",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled latitude value."
+      "description": "Sampled latitude value.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/longitude",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled longitude value."
+      "description": "Sampled longitude value.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/altitude",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled altitude value."
+      "description": "Sampled altitude value.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/accuracy",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled accuracy of the latitude and longitude properties."
+      "description": "Sampled accuracy of the latitude and longitude properties.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/altitudeAccuracy",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled accuracy of the altitude property."
+      "description": "Sampled accuracy of the altitude property.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/heading",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled value representing the direction towards which the device is facing."
+      "description": "Sampled value representing the direction towards which the device is facing.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/speed",
       "type": "double",
       "explicit_timestamp": true,
-      "description": "Sampled value representing the velocity of the device."
+      "description": "Sampled value representing the velocity of the device.",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
     }
   ]
 }

--- a/io.edgehog.devicemanager.LedBehavior.json
+++ b/io.edgehog.devicemanager.LedBehavior.json
@@ -8,6 +8,7 @@
     {
       "endpoint": "/%{led_id}/behavior",
       "type": "string",
+      "reliability": "unique",
       "description": "Enum describing the behavior of the given led. Possible values: [Blink60Seconds | DoubleBlink60Seconds | SlowBlink60Seconds]",
       "doc": "Blink60Seconds: Blinking\nDoubleBlink60Seconds: Double blinking\nSlowBlink60Seconds: Slow blinking",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.OTARequest.json
+++ b/io.edgehog.devicemanager.OTARequest.json
@@ -9,7 +9,7 @@
         {
             "endpoint": "/request/url",
             "type": "string",
-            "reliability": "guaranteed",
+            "reliability": "unique",
             "database_retention_policy": "use_ttl",
             "database_retention_ttl": 31556952,
             "description": "File URL"
@@ -17,7 +17,7 @@
         {
             "endpoint": "/request/uuid",
             "type": "string",
-            "reliability": "guaranteed",
+            "reliability": "unique",
             "database_retention_policy": "use_ttl",
             "database_retention_ttl": 31556952,
             "description": "Request identifier"

--- a/io.edgehog.devicemanager.OTAResponse.json
+++ b/io.edgehog.devicemanager.OTAResponse.json
@@ -9,7 +9,7 @@
         {
             "endpoint": "/response/uuid",
             "type": "string",
-            "reliability": "guaranteed",
+            "reliability": "unique",
             "database_retention_policy": "use_ttl",
             "database_retention_ttl": 31556952,
             "description": "Request identifier"
@@ -17,7 +17,7 @@
         {
             "endpoint": "/response/status",
             "type": "string",
-            "reliability": "guaranteed",
+            "reliability": "unique",
             "database_retention_policy": "use_ttl",
             "database_retention_ttl": 31556952,
             "description": "Possible values: [ InProgress | Error | Done ]"
@@ -25,7 +25,7 @@
         {
             "endpoint": "/response/statusCode",
             "type": "string",
-            "reliability": "guaranteed",
+            "reliability": "unique",
             "database_retention_policy": "use_ttl",
             "database_retention_ttl": 31556952
         }


### PR DESCRIPTION
- Add QoS 2 to `io.edgehog.devicemanager.Commands.json`, `io.edgehog.devicemanager.LedBehavior`, `io.edgehog.devicemanager.OTARequest` and `io.edgehog.devicemanager.OTAResponse` useful to assure the device received the message.
- Add a TTL of two months to `io.edgehog.devicemanager.Geolocation` for safer server-side storage.