### PR TITLE
Remove whitespaces at the end of lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0] - Unreleased
 ### Added
-- Add `operation` endpoint to `io.edgehog.devicemanager.OTARequest` interface ([#52](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/52)).
-- Add `io.edgehog.devicemanager.OTAEvent` interface ([#54](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/54), [#55](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/55)).
+- Add `operation` endpoint to `io.edgehog.devicemanager.OTARequest` interface
+  ([#52](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/52)).
+- Add `io.edgehog.devicemanager.OTAEvent` interface
+  ([#54](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/54),
+  [#55](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/55)).
 
 ### Changed
-- Bump `io.edgehog.devicemanager.OTARequest` to 1.0 changing endpoints reliability to `unreliable` ([#51](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/51)).
+- Bump `io.edgehog.devicemanager.OTARequest` to 1.0 changing endpoints reliability to `unreliable`
+  ([#51](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/51)).
 
 ### Removed
-- Remove `io.edgehog.devicemanager.OTAResponse` interface ([#56](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/56)).
+- Remove `io.edgehog.devicemanager.OTAResponse` interface
+  ([#56](https://github.com/edgehog-device-manager/edgehog-astarte-interfaces/issues/56)).
 
 
 ## [0.5.2] - 2022-06-22

--- a/io.edgehog.devicemanager.OTARequest.json
+++ b/io.edgehog.devicemanager.OTARequest.json
@@ -11,8 +11,8 @@
             "type": "string",
             "database_retention_policy": "use_ttl",
             "database_retention_ttl": 31556952,
-            "description": "OTA Request operation", 
-            "doc": "Value is one of the following strings:\n\n - `Update`: push an OTA update operation.\n - `Cancel`: cancel an OTA update if it can still be cancelled."        
+            "description": "OTA Request operation",
+            "doc": "Value is one of the following strings:\n\n - `Update`: push an OTA update operation.\n - `Cancel`: cancel an OTA update if it can still be cancelled."
         },
         {
             "endpoint": "/request/url",


### PR DESCRIPTION
- Remove whitespaces at the end of lines of OTARequest interface.
- Adjust max length of changelog line to 100 chars.