### PR TITLE
feat(forwarder): add interfaces to handle a remote terminal session

### DIFF
--- a/io.edgehog.devicemanager.ForwarderSessionsState.json
+++ b/io.edgehog.devicemanager.ForwarderSessionsState.json
@@ -1,0 +1,16 @@
+{
+  "interface_name": "io.edgehog.devicemanager.ForwarderSessionsState",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "properties",
+  "ownership": "device",
+  "description": "This property is set by a device to provide information about the status of a remote terminal session.",
+  "mappings": [
+    {
+      "endpoint": "/%{session_token}/status",
+      "type": "string",
+      "description": "Indicates if the device is connecting, connected or disconnected to a remote terminal session.",
+      "doc": "An enum with the following possible values: Connecting | Connected | Disconnected."
+    }
+  ]
+}

--- a/io.edgehog.devicemanager.RemoteTerminalRequest.json
+++ b/io.edgehog.devicemanager.RemoteTerminalRequest.json
@@ -1,0 +1,32 @@
+{
+  "interface_name": "io.edgehog.devicemanager.RemoteTerminalRequest",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "server",
+  "aggregation": "object",
+  "description": "Configuration to open a remote terminal from a device to a certain host.",
+  "mappings": [
+    {
+      "endpoint": "/request/session_token",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The session token thanks to which the device can authenticates itself through Edgehog."
+    },
+    {
+      "endpoint": "/request/port",
+      "type": "integer",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The host port the device must connect to."
+    },
+    {
+      "endpoint": "/request/host",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "description": "The IP address or host name the device must connect to."
+    }
+  ]
+}


### PR DESCRIPTION
Two interfaces has been added to allow managing a remote terminal session:
- `io.edgehog.devicemanager.RemoteTerminalRequest`:  a server-owned interface carrying the configuration data necessary to open a remote terminal from a device to a certain host
- `io.edgehog.devicemanager.ForwarderSessionsState`: a device-owned interface used by a device to provide information about the status of a remote terminal session (connected / disconnected)

close #62 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
