### PR TITLE
feat(container): add the deployment id to create request 

### DIFF
--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container."
     },
     {
+      "endpoint": "/container/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the container",
+      "doc": "The deployment in which the container is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/container/imageId",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -76,7 +76,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container environment",
-      "doc": "Array of KEY=value environment variables"
+      "doc": "Array of key=value environment variables. The key cannot contain `=`."
     },
     {
       "endpoint": "/container/binds",

--- a/io.edgehog.devicemanager.apps.CreateImageRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateImageRequest.json
@@ -18,6 +18,15 @@
       "doc": "Unique id for the container image."
     },
     {
+      "endpoint": "/image/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 600,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the image",
+      "doc": "The deployment in which the image is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/image/reference",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container network."
     },
     {
+      "endpoint": "/network/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the network",
+      "doc": "The deployment in which the network is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/network/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -49,7 +49,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network driver options",
-      "doc": "An array of key=value options to set for the driver."
+      "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."
     }
   ]
 }

--- a/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -31,7 +31,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Volume driver options",
-      "doc": "An array of key=value options to set for the driver."
+      "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."
     }
   ]
 }

--- a/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the volume."
     },
     {
+      "endpoint": "/volume/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the volume",
+      "doc": "The deployment in which the volume is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/volume/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",


### PR DESCRIPTION
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->

By providing a deployment id for the create requests, the device can
send DeploymentEvents (mainly errors) regarding the create requests, so
we can signal Edgehog when a create fails and the deployment cannot
continue.