### PR TITLE
refactor(container): remove the image key from the create request

### DIFF
--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -52,15 +52,6 @@
       "doc": "The ids of the volumes to mount on the container."
     },
     {
-      "endpoint": "/container/image",
-      "type": "string",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
-      "reliability": "guaranteed",
-      "description": "Container image",
-      "doc": "TODO: this will be remove (by only sending the image_id), when it will be supported on the device."
-    },
-    {
       "endpoint": "/container/hostname",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container."
     },
     {
+      "endpoint": "/container/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the container",
+      "doc": "The deployment in which the container is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/container/imageId",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -76,7 +76,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container environment",
-      "doc": "Array of KEY=value environment variables"
+      "doc": "Array of key=value environment variables. The key cannot contain `=`."
     },
     {
       "endpoint": "/container/binds",

--- a/io.edgehog.devicemanager.apps.CreateImageRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateImageRequest.json
@@ -18,6 +18,15 @@
       "doc": "Unique id for the container image."
     },
     {
+      "endpoint": "/image/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 600,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the image",
+      "doc": "The deployment in which the image is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/image/reference",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the container network."
     },
     {
+      "endpoint": "/network/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the network",
+      "doc": "The deployment in which the network is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/network/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -49,7 +49,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network driver options",
-      "doc": "An array of key=value options to set for the driver."
+      "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."
     }
   ]
 }

--- a/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -31,7 +31,7 @@
       "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Volume driver options",
-      "doc": "An array of key=value options to set for the driver."
+      "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."
     }
   ]
 }

--- a/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -16,6 +16,15 @@
       "doc": "Unique id for the volume."
     },
     {
+      "endpoint": "/volume/deploymentId",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "Reference to a Deployment using the volume",
+      "doc": "The deployment in which the volume is used, so the device can send deployment events to Astarte for the create request"
+    },
+    {
       "endpoint": "/volume/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",


### PR DESCRIPTION
The device now supports having only the image_id field.