### PR TITLE
feat(container): add extra hosts field 

### DIFF
--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -106,6 +106,15 @@
       "doc": "Array of ip:[host_port:]container_port[/protocol] | [hostPort:]containerPort[/protocol]. Protocol is TCP by default"
     },
     {
+      "endpoint": "/container/extraHosts",
+      "type": "stringarray",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 31556952,
+      "reliability": "guaranteed",
+      "description": "List of hostname/IP to add to the container's /etc/hosts",
+      "doc": "A list of hostnames/IP mappings to add to the container's /etc/hosts file. Specified in the form [\"hostname:IP\"]. You can use the `host-gateway` to connect to the host IP"
+    },
+    {
       "endpoint": "/container/privileged",
       "type": "boolean",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.apps.DeploymentEvent.json
+++ b/io.edgehog.devicemanager.apps.DeploymentEvent.json
@@ -11,14 +11,16 @@
       "type": "string",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
+      "explicit_timestamp": true,
       "description": "Deployment status",
-      "doc": "Possible values: [Starting, Stopping, Updating, Deleting, Error]"
+      "doc": "Possible values: [Starting, Started, Stopping, Stopped, Updating, Deleting, Error]"
     },
     {
       "endpoint": "/%{deployment_id}/message",
       "type": "string",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 31556952,
+      "explicit_timestamp": true,
       "description": "Optional message for the event"
     }
   ]


### PR DESCRIPTION
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
A list of hostnames/IP mappings to add to the container's /etc/hosts
file. Specified in the form ["hostname:IP"].

One use case is to resolve the host.docker.internal to the host-gateway
to permit a container to communicate with the host service.