### PR TITLE
feat(fileTransfer): Add transfer type field to file transfer interfaces

### DIFF
--- a/io.edgehog.devicemanager.fileTransfer.Progress.json
+++ b/io.edgehog.devicemanager.fileTransfer.Progress.json
@@ -16,6 +16,14 @@
       "description": "Transfer ID for the file"
     },
     {
+      "endpoint": "/request/type",
+      "type": "string",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Direction of the file transfer",
+      "doc": "Specifies the direction of the transfer. Allowed values: 'server_to_device' or 'device_to_server'."
+    },
+    {
       "endpoint": "/request/progress",
       "type": "integer",
       "database_retention_policy": "use_ttl",

--- a/io.edgehog.devicemanager.fileTransfer.Response.json
+++ b/io.edgehog.devicemanager.fileTransfer.Response.json
@@ -18,13 +18,22 @@
       "doc": "Can be either for download or upload transfers."
     },
     {
+      "endpoint": "/request/type",
+      "type": "string",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Direction of the file transfer",
+      "doc": "Specifies the direction of the transfer. Allowed values: 'server_to_device' or 'device_to_server'."
+    },
+    {
       "endpoint": "/request/code",
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
       "database_retention_ttl": 3600,
       "description": "Success or error code for the transfer",
-      "doc": "A 0 code is a success, errors are POSIX errorno"
+      "doc": "A 0 code is a success, errors are POSIX errno."
     },
     {
       "endpoint": "/request/message",


### PR DESCRIPTION
- Introduce `/request/type` field to specify `server_to_device`or `device_to_server`
- Enables backend to target correct database table directly.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
