### PR TITLE
fix: Update preferred spelling in Capabilities

### DIFF
--- a/io.edgehog.devicemanager.fileTransfer.Capabilities.json
+++ b/io.edgehog.devicemanager.fileTransfer.Capabilities.json
@@ -18,7 +18,7 @@
       "endpoint": "/unixPermissions",
       "type": "boolean",
       "description": "Support unix file mode, user id and group id.",
-      "doc": "Flag to support setting the file mode, user and group ownership of a transfered file in a unix system."
+      "doc": "Flag to support setting the file mode, user and group ownership of a transferred file in a unix system."
     },
     {
       "endpoint": "/targets",


### PR DESCRIPTION
Edgehog has a workflow that checks for preferred spelling in the codebase. This commit updates the Capabilities file to reflect the preferred spelling.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
