### PR TITLE
fix: remove deafult database retention ttls

### DIFF
--- a/io.edgehog.devicemanager.BatteryStatus.json
+++ b/io.edgehog.devicemanager.BatteryStatus.json
@@ -12,7 +12,6 @@
       "explicit_timestamp": true,
       "description": "Battery level estimated percentage [0.0%-100.0%]",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{battery_slot}/levelAbsoluteError",
@@ -20,7 +19,6 @@
       "explicit_timestamp": true,
       "description": "Battery level measurement absolute error [0.0-100.0]",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{battery_slot}/status",
@@ -28,7 +26,6 @@
       "explicit_timestamp": true,
       "description": "Battery status string, any of: Charging, Discharging, Idle, EitherIdleOrCharging, Failure, Removed, Unknown",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     }
   ]
 }

--- a/io.edgehog.devicemanager.BatteryStatus.json
+++ b/io.edgehog.devicemanager.BatteryStatus.json
@@ -11,24 +11,21 @@
       "type": "double",
       "explicit_timestamp": true,
       "description": "Battery level estimated percentage [0.0%-100.0%]",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{battery_slot}/levelAbsoluteError",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Battery level measurement absolute error [0.0-100.0]",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{battery_slot}/status",
       "type": "string",
       "explicit_timestamp": true,
       "description": "Battery status string, any of: Charging, Discharging, Idle, EitherIdleOrCharging, Failure, Removed, Unknown",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     }
   ]
 }

--- a/io.edgehog.devicemanager.CellularConnectionStatus.json
+++ b/io.edgehog.devicemanager.CellularConnectionStatus.json
@@ -10,7 +10,6 @@
       "endpoint": "/%{id}/carrier",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Connectivity carrier operator name."
     },
@@ -18,7 +17,6 @@
       "endpoint": "/%{id}/cellId",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The Cell ID in hexadecimal format, either 16 bit for 2G or 28 bit for 3G or 4G."
     },
@@ -26,7 +24,6 @@
       "endpoint": "/%{id}/mobileCountryCode",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The mobile country code (MCC) for the device's home network. Valid range: 0–999."
     },
@@ -34,7 +31,6 @@
       "endpoint": "/%{id}/mobileNetworkCode",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The Mobile Network Code for the device's home network. This is the MNC for GSM, WCDMA, LTE and NR. CDMA uses the System ID (SID). Valid range for MNC: 0–999. Valid range for SID: 0–32767."
     },
@@ -42,7 +38,6 @@
       "endpoint": "/%{id}/localAreaCode",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Two byte location area code in hexadecimal format."
     },
@@ -50,7 +45,6 @@
       "endpoint": "/%{id}/registrationStatus",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "GSM/LTE registration status. Possible values: [NotRegistered, Registered, SearchingOperator, RegistrationDenied, Unknown, RegisteredRoaming]"
     },
@@ -58,7 +52,6 @@
       "endpoint": "/%{id}/rssi",
       "type": "double",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Signal strength of the device in dBm."
     },
@@ -66,7 +59,6 @@
       "endpoint": "/%{id}/technology",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Access Technology. Possible values [GSM, GSMCompact, UTRAN, GSMwEGPRS, UTRANwHSDPA, UTRANwHSUPA, UTRANwHSDPAandHSUPA, EUTRAN]"
     }

--- a/io.edgehog.devicemanager.CellularConnectionStatus.json
+++ b/io.edgehog.devicemanager.CellularConnectionStatus.json
@@ -10,7 +10,6 @@
       "endpoint": "/%{id}/carrier",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Connectivity carrier operator name."
     },
@@ -18,7 +17,6 @@
       "endpoint": "/%{id}/cellId",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The Cell ID in hexadecimal format, either 16 bit for 2G or 28 bit for 3G or 4G."
     },
@@ -26,7 +24,6 @@
       "endpoint": "/%{id}/mobileCountryCode",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The mobile country code (MCC) for the device's home network. Valid range: 0–999."
     },
@@ -34,7 +31,6 @@
       "endpoint": "/%{id}/mobileNetworkCode",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The Mobile Network Code for the device's home network. This is the MNC for GSM, WCDMA, LTE and NR. CDMA uses the System ID (SID). Valid range for MNC: 0–999. Valid range for SID: 0–32767."
     },
@@ -42,7 +38,6 @@
       "endpoint": "/%{id}/localAreaCode",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Two byte location area code in hexadecimal format."
     },
@@ -50,7 +45,6 @@
       "endpoint": "/%{id}/registrationStatus",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "GSM/LTE registration status. Possible values: [NotRegistered, Registered, SearchingOperator, RegistrationDenied, Unknown, RegisteredRoaming]"
     },
@@ -58,7 +52,6 @@
       "endpoint": "/%{id}/rssi",
       "type": "double",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Signal strenght of the device in dBm."
     },
@@ -66,7 +59,6 @@
       "endpoint": "/%{id}/technology",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Access Technology. Possible values [GSM, GSMCompact, UTRAN, GSMwEGPRS, UTRANwHSDPA, UTRANwHSUPA, UTRANwHSDPAandHSUPA, EUTRAN]"
     }

--- a/io.edgehog.devicemanager.ForwarderSessionRequest.json
+++ b/io.edgehog.devicemanager.ForwarderSessionRequest.json
@@ -11,28 +11,24 @@
       "endpoint": "/request/session_token",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "The session token thanks to which the device can authenticates itself through Edgehog."
     },
     {
       "endpoint": "/request/port",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "The host port the device must connect to."
     },
     {
       "endpoint": "/request/host",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "The IP address or host name the device must connect to."
     },
     {
       "endpoint": "/request/secure",
       "type": "boolean",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "Indicates whether the connection should use TLS, i.e. 'ws' or 'wss' scheme."
     }
   ]

--- a/io.edgehog.devicemanager.Geolocation.json
+++ b/io.edgehog.devicemanager.Geolocation.json
@@ -14,7 +14,6 @@
       "explicit_timestamp": true,
       "description": "Sampled latitude value.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/longitude",
@@ -22,7 +21,6 @@
       "explicit_timestamp": true,
       "description": "Sampled longitude value.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/altitude",
@@ -30,7 +28,6 @@
       "explicit_timestamp": true,
       "description": "Sampled altitude value.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/accuracy",
@@ -38,7 +35,6 @@
       "explicit_timestamp": true,
       "description": "Sampled accuracy of the latitude and longitude properties.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/altitudeAccuracy",
@@ -46,7 +42,6 @@
       "explicit_timestamp": true,
       "description": "Sampled accuracy of the altitude property.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/heading",
@@ -54,7 +49,6 @@
       "explicit_timestamp": true,
       "description": "Sampled value representing the direction towards which the device is facing.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{id}/speed",
@@ -62,7 +56,6 @@
       "explicit_timestamp": true,
       "description": "Sampled value representing the velocity of the device.",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     }
   ]
 }

--- a/io.edgehog.devicemanager.Geolocation.json
+++ b/io.edgehog.devicemanager.Geolocation.json
@@ -13,56 +13,49 @@
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled latitude value.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{id}/longitude",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled longitude value.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{id}/altitude",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled altitude value.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{id}/accuracy",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled accuracy of the latitude and longitude properties.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{id}/altitudeAccuracy",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled accuracy of the altitude property.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{id}/heading",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled value representing the direction towards which the device is facing.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{id}/speed",
       "type": "double",
       "explicit_timestamp": true,
       "description": "Sampled value representing the velocity of the device.",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     }
   ]
 }

--- a/io.edgehog.devicemanager.LedBehavior.json
+++ b/io.edgehog.devicemanager.LedBehavior.json
@@ -12,7 +12,6 @@
       "description": "Enum describing the behavior of the given led. Possible values: [Blink60Seconds | DoubleBlink60Seconds | SlowBlink60Seconds]",
       "doc": "Blink60Seconds: Blinking\nDoubleBlink60Seconds: Double blinking\nSlowBlink60Seconds: Slow blinking",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     }
   ]
 }

--- a/io.edgehog.devicemanager.LedBehavior.json
+++ b/io.edgehog.devicemanager.LedBehavior.json
@@ -11,8 +11,7 @@
       "reliability": "unique",
       "description": "Enum describing the behavior of the given led. Possible values: [Blink60Seconds | DoubleBlink60Seconds | SlowBlink60Seconds]",
       "doc": "Blink60Seconds: Blinking\nDoubleBlink60Seconds: Double blinking\nSlowBlink60Seconds: Slow blinking",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     }
   ]
 }

--- a/io.edgehog.devicemanager.OTAEvent.json
+++ b/io.edgehog.devicemanager.OTAEvent.json
@@ -13,7 +13,7 @@
       "type": "string",
       "reliability": "unique",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "explicit_timestamp": true,
       "description": "OTA Request identifier."
     },
@@ -22,7 +22,7 @@
       "type": "string",
       "reliability": "unique",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "explicit_timestamp": true,
       "description": "OTA Update status.",
       "doc": "Value is one of the following strings:\n\n - `Acknowledged`: the device received an OTA Request.\n - `Downloading`: an update is in the process of downloading.\n - `Deploying`: an update is in the process of deploying.\n - `Deployed`: an update deployed on the device.\n - `Rebooting`: the device is in the process of rebooting.\n - `Success`: an update succeeded. This is a final status of OTA Update.\n - `Error`: an error happened during the update. Also this status can be used to notify about handled errors.\n - `Failure`: an update failed. This is a final status of OTA Update."
@@ -32,7 +32,7 @@
       "type": "integer",
       "reliability": "unique",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "explicit_timestamp": true,
       "description": "Current OTA Update status progress percentage [0%-100%].",
       "doc": "Every OTA Update status has own progress that starts from 0 and ends at 100, for example (pairs of `\"status, progress\"`): `\"Downloading, 0\"`, `\"Downloading, 50\"`, `\"Downloading, 100\"`, `\"Deploying, 10\"`, etc."
@@ -42,7 +42,7 @@
       "type": "string",
       "reliability": "unique",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "explicit_timestamp": true,
       "description": "Status code expands OTA Update status with additional information.",
       "doc": "Some common status codes are:\n\n  - `InvalidRequest`: an update request contains incorrect data.\n - `UpdateAlreadyInProgress`: another update is currently in progress.\n  - `NetworkError`: a network error happened during the update.\n  - `IOError`: a filesystem error happened during the update.\n  - `InternalError`: an internal error happened during the update.\n  - `InvalidBaseImage`: an update failed to apply due to an invalid base image.\n  - `SystemRollback`: a system rollback has occurred.\n  - `Canceled`: an update was canceled."
@@ -52,7 +52,7 @@
       "type": "string",
       "reliability": "unique",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "explicit_timestamp": true,
       "description": "Contains internal message for status code or empty string otherwise."
     }

--- a/io.edgehog.devicemanager.OTARequest.json
+++ b/io.edgehog.devicemanager.OTARequest.json
@@ -10,7 +10,7 @@
       "endpoint": "/request/operation",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "description": "OTA Request operation",
       "doc": "Value is one of the following strings:\n\n - `Update`: push an OTA update operation.\n - `Cancel`: cancel an OTA update if it can still be cancelled."
     },
@@ -18,7 +18,7 @@
       "endpoint": "/request/url",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "description": "File URL",
       "doc": "If the operation is Update, this will contain the URL that can be used to download the Update.\n If the operation is Cancel, this will be an empty string.\n Note that the URL will be valid only until the OTA update is active (i.e. it didn't reach a Failure or Success state), after that it's possible that the URL can become invalid."
     },
@@ -26,7 +26,7 @@
       "endpoint": "/request/uuid",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
+      "database_retention_ttl": 7889238,
       "description": "Request identifier",
       "doc": "A UUID that uniquely identifies the OTA request. It must be stored when receiving an Update operation so that it can be matched against in case a Cancel operation is received."
     }

--- a/io.edgehog.devicemanager.StorageUsage.json
+++ b/io.edgehog.devicemanager.StorageUsage.json
@@ -12,7 +12,6 @@
       "explicit_timestamp": true,
       "description": "Total storage size in bytes",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/%{label}/freeBytes",
@@ -20,7 +19,6 @@
       "explicit_timestamp": true,
       "description": "Available storage bytes",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     }
   ]
 }

--- a/io.edgehog.devicemanager.StorageUsage.json
+++ b/io.edgehog.devicemanager.StorageUsage.json
@@ -11,16 +11,14 @@
       "type": "longinteger",
       "explicit_timestamp": true,
       "description": "Total storage size in bytes",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/%{label}/freeBytes",
       "type": "longinteger",
       "explicit_timestamp": true,
       "description": "Available storage bytes",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     }
   ]
 }

--- a/io.edgehog.devicemanager.SystemStatus.json
+++ b/io.edgehog.devicemanager.SystemStatus.json
@@ -12,7 +12,6 @@
       "explicit_timestamp": true,
       "description": "Available memory (Bytes)",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/systemStatus/bootId",
@@ -20,7 +19,6 @@
       "explicit_timestamp": true,
       "description": "UUID representing the Boot Id",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/systemStatus/taskCount",
@@ -28,7 +26,6 @@
       "explicit_timestamp": true,
       "description": "Number of running tasks or processes",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     },
     {
       "endpoint": "/systemStatus/uptimeMillis",
@@ -36,7 +33,6 @@
       "explicit_timestamp": true,
       "description": "Get time in milliseconds since boot",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
     }
   ]
 }

--- a/io.edgehog.devicemanager.SystemStatus.json
+++ b/io.edgehog.devicemanager.SystemStatus.json
@@ -11,32 +11,28 @@
       "type": "longinteger",
       "explicit_timestamp": true,
       "description": "Available memory (Bytes)",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/systemStatus/bootId",
       "type": "string",
       "explicit_timestamp": true,
       "description": "UUID representing the Boot Id",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/systemStatus/taskCount",
       "type": "integer",
       "explicit_timestamp": true,
       "description": "Number of running tasks or processes",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     },
     {
       "endpoint": "/systemStatus/uptimeMillis",
       "type": "longinteger",
       "explicit_timestamp": true,
       "description": "Get time in milliseconds since boot",
-      "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000
+      "database_retention_policy": "use_ttl"
     }
   ]
 }

--- a/io.edgehog.devicemanager.WiFiScanResults.json
+++ b/io.edgehog.devicemanager.WiFiScanResults.json
@@ -10,7 +10,6 @@
       "endpoint": "/ap/channel",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The channel over which the client is communicating with the access point.",
       "doc": "The channel represents one of the ranges into which the reference frequency is divided and it's identified by an integer number in the range 1 - 165, depending on the frequency itself and the region."
@@ -19,7 +18,6 @@
       "endpoint": "/ap/connected",
       "type": "boolean",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Identifies if the device is connected to this Access Point"
     },
@@ -27,7 +25,6 @@
       "endpoint": "/ap/essid",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Extended Service Set Identification of the current AP, empty string if the AP is hidden."
     },
@@ -35,7 +32,6 @@
       "endpoint": "/ap/macAddress",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "Lower case mac address string formatted like `de:ad:be:ff:11:22`."
     },
@@ -43,7 +39,6 @@
       "endpoint": "/ap/rssi",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 5184000,
       "explicit_timestamp": true,
       "description": "The current signal strength measured in dBm."
     }

--- a/io.edgehog.devicemanager.apps.CreateContainerRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateContainerRequest.json
@@ -10,7 +10,6 @@
       "endpoint": "/container/id",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Create Container Request id",
       "doc": "Unique id for the container."
@@ -19,7 +18,6 @@
       "endpoint": "/container/deploymentId",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Reference to a Deployment using the container",
       "doc": "The deployment in which the container is used, so the device can send deployment events to Astarte for the create request"
@@ -28,7 +26,6 @@
       "endpoint": "/container/imageId",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container image id",
       "doc": "The id of the image to use when creating the container."
@@ -37,7 +34,6 @@
       "endpoint": "/container/networkIds",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container network ids",
       "doc": "The ids of the network to connect with the container."
@@ -46,7 +42,6 @@
       "endpoint": "/container/volumeIds",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container volume ids",
       "doc": "The ids of the volumes to mount on the container."
@@ -55,7 +50,6 @@
       "endpoint": "/container/deviceMappingIds",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container device mappings ids",
       "doc": "The ids of the device mappings to mount on the container."
@@ -64,7 +58,6 @@
       "endpoint": "/container/hostname",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container hostname",
       "doc": "The hostname to use for the container, as a valid RFC 1123 hostname."
@@ -73,7 +66,6 @@
       "endpoint": "/container/restartPolicy",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container restart policy",
       "doc": "The behavior to apply when the container exits. Possible values are: ['', 'no', 'always' 'unless-stopped', 'on-failure']"
@@ -82,7 +74,6 @@
       "endpoint": "/container/env",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container environment",
       "doc": "Array of key=value environment variables. The key cannot contain `=`."
@@ -91,7 +82,6 @@
       "endpoint": "/container/binds",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container binds",
       "doc": "A list of volume bindings for this container. Each volume binding is a string in one of these forms: host-src:container-dest[:options], or volume-name:container-dest[:options]. The container-dest must be an absolute path."
@@ -100,7 +90,6 @@
       "endpoint": "/container/networkMode",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network mode used for this container.",
       "doc": "Supported standard values are: bridge, host, none, and container:<name|id>. Any other value is taken as a custom network's name to which this container should connect to. If you are using a different container engine than docker, there could be other values."
@@ -109,7 +98,6 @@
       "endpoint": "/container/portBindings",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Container port bindings",
       "doc": "Array of ip:[host_port:]container_port[/protocol] | [hostPort:]containerPort[/protocol]. Protocol is TCP by default"
@@ -118,7 +106,6 @@
       "endpoint": "/container/extraHosts",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "List of hostname/IP to add to the container's /etc/hosts",
       "doc": "A list of hostnames/IP mappings to add to the container's /etc/hosts file. Specified in the form [\"hostname:IP\"]. You can use the `host-gateway` to connect to the host IP"
@@ -127,7 +114,6 @@
       "endpoint": "/container/capAdd",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "A list of kernel capabilities to add to the container.",
       "doc": "A list of kernel capabilities to add to the container."
@@ -136,7 +122,6 @@
       "endpoint": "/container/capDrop",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "A list of kernel capabilities to drop from the container.",
       "doc": "A list of kernel capabilities to drop from the container."
@@ -145,7 +130,6 @@
       "endpoint": "/container/cpuPeriod",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "The length of a CPU period in microseconds.",
       "doc": "Unset if the value is -1 (or negative) and the cpuQuota must also be unset."
@@ -154,7 +138,6 @@
       "endpoint": "/container/cpuQuota",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Microseconds of CPU time that the container can get in a CPU period.",
       "doc": "Unset if the value is -1 (or negative) and the cpuPeriod must also be unset."
@@ -163,7 +146,6 @@
       "endpoint": "/container/cpuRealtimePeriod",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "The length of a CPU real-time period in microseconds.",
       "doc": "The length of a CPU real-time period in microseconds. Set to 0 to allocate no time allocated to real-time tasks. Unset if the value is -1 (or negative)."
@@ -172,7 +154,6 @@
       "endpoint": "/container/cpuRealtimeRuntime",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "The length of a CPU real-time runtime in microseconds.",
       "doc": "The length of a CPU real-time runtime in microseconds. Set to 0 to allocate no time allocated to real-time tasks. Unset if the value is -1 (or negative)."
@@ -181,7 +162,6 @@
       "endpoint": "/container/memory",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Memory limit in bytes.",
       "doc": "Memory limit in bytes. Default to 0 for unlimited. Unset if the value is -1 (or negative)."
@@ -190,7 +170,6 @@
       "endpoint": "/container/memoryReservation",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Memory soft limit in bytes. Default to 0 for unlimited. Unset if the value is -1 (or negative)."
     },
@@ -198,7 +177,6 @@
       "endpoint": "/container/memorySwap",
       "type": "longinteger",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Total memory limit (memory + swap).",
       "doc": "Total memory limit (memory + swap). Set as -1 to enable unlimited swap. Unset if the value is -2 (or more negative)."
@@ -207,7 +185,6 @@
       "endpoint": "/container/memorySwappiness",
       "type": "integer",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Memory swappiness",
       "doc": "Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100. Unset if the value is -1 (or negative)."
@@ -216,7 +193,6 @@
       "endpoint": "/container/volumeDriver",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Driver that this container uses to mount volumes."
     },
@@ -224,7 +200,6 @@
       "endpoint": "/container/storageOpt",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Storage driver options for this container.",
       "doc": "Storage driver options for this container, in the form \"size=120G\"."
@@ -233,7 +208,6 @@
       "endpoint": "/container/readOnlyRootfs",
       "type": "boolean",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Mount the container's root filesystem as read only."
     },
@@ -241,7 +215,6 @@
       "endpoint": "/container/tmpfs",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "A map of container directories which should be replaced by tmpfs mounts.",
       "doc": "A map of container directories which should be replaced by tmpfs mounts, and their corresponding mount options. For example:\n \"/run=rw,noexec,nosuid,size=65536k\""
@@ -250,7 +223,6 @@
       "endpoint": "/container/privileged",
       "type": "boolean",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Run privileged",
       "doc": "Runs the exec process with extended privileges."

--- a/io.edgehog.devicemanager.apps.CreateDeploymentRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateDeploymentRequest.json
@@ -10,7 +10,6 @@
       "endpoint": "/deployment/id",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Create Deployment Request id",
       "doc": "Unique id for the deployment."
@@ -19,7 +18,6 @@
       "endpoint": "/deployment/containers",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Deployment containers",
       "doc": "Containers used by the deployment."

--- a/io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateDeviceMappingRequest.json
@@ -10,7 +10,6 @@
       "endpoint": "/deviceMapping/id",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Create Device Mapping Request id",
       "doc": "Unique id for the container."
@@ -19,7 +18,6 @@
       "endpoint": "/deviceMapping/deploymentId",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Reference to a Deployment using the device mapping",
       "doc": "The deployment in which the device mapping is used, so the device can send deployment events to Astarte for the create request"
@@ -28,7 +26,6 @@
       "endpoint": "/deviceMapping/pathOnHost",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Path on host for the device",
       "doc": "Path on host for the device, for example '/dev/deviceName'"
@@ -37,7 +34,6 @@
       "endpoint": "/deviceMapping/pathInContainer",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Path in the container for the device",
       "doc": "Path in the container for the device, for example '/dev/deviceName'"
@@ -46,7 +42,6 @@
       "endpoint": "/deviceMapping/cGroupPermissions",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Permissions on the device.",
       "doc": "Permissions on the device, for example 'mrw'"

--- a/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateNetworkRequest.json
@@ -10,7 +10,6 @@
       "endpoint": "/network/id",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Create Network Request id",
       "doc": "Unique id for the container network."
@@ -19,7 +18,6 @@
       "endpoint": "/network/deploymentId",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Reference to a Deployment using the network",
       "doc": "The deployment in which the network is used, so the device can send deployment events to Astarte for the create request"
@@ -28,7 +26,6 @@
       "endpoint": "/network/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network driver",
       "doc": "Name of the network driver plugin to use."
@@ -37,7 +34,6 @@
       "endpoint": "/network/internal",
       "type": "boolean",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Internal network",
       "doc": "Restrict external access to the network."
@@ -46,7 +42,6 @@
       "endpoint": "/network/enableIpv6",
       "type": "boolean",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Enable IPv6",
       "doc": "Enable IPv6 on the network."
@@ -55,7 +50,6 @@
       "endpoint": "/network/options",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Network driver options",
       "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."

--- a/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
+++ b/io.edgehog.devicemanager.apps.CreateVolumeRequest.json
@@ -10,7 +10,6 @@
       "endpoint": "/volume/id",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Create Volume Request id",
       "doc": "Unique id for the volume."
@@ -19,7 +18,6 @@
       "endpoint": "/volume/deploymentId",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Reference to a Deployment using the volume",
       "doc": "The deployment in which the volume is used, so the device can send deployment events to Astarte for the create request"
@@ -28,7 +26,6 @@
       "endpoint": "/volume/driver",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Volume driver name",
       "doc": "Name of the volume driver to use."
@@ -37,7 +34,6 @@
       "endpoint": "/volume/options",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "reliability": "guaranteed",
       "description": "Volume driver options",
       "doc": "An array of key=value options to set for the driver. The key cannot contain an `=`."

--- a/io.edgehog.devicemanager.apps.DeploymentCommand.json
+++ b/io.edgehog.devicemanager.apps.DeploymentCommand.json
@@ -10,7 +10,6 @@
       "endpoint": "/%{deployment_id}/command",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "Deployment command",
       "doc": "Possible values [Start, Stop, Delete]"
     }

--- a/io.edgehog.devicemanager.apps.DeploymentEvent.json
+++ b/io.edgehog.devicemanager.apps.DeploymentEvent.json
@@ -10,7 +10,6 @@
       "endpoint": "/%{deployment_id}/status",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "explicit_timestamp": true,
       "description": "Deployment status",
       "doc": "Possible values: [Starting, Started, Stopping, Stopped, Updating, Deleting, Error]"
@@ -19,7 +18,6 @@
       "endpoint": "/%{deployment_id}/message",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "explicit_timestamp": true,
       "description": "Optional message for the event"
     },
@@ -27,7 +25,6 @@
       "endpoint": "/%{deployment_id}/addInfo",
       "type": "stringarray",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "explicit_timestamp": true,
       "description": "Additional info",
       "doc": "Additional info about the event."

--- a/io.edgehog.devicemanager.apps.DeploymentUpdate.json
+++ b/io.edgehog.devicemanager.apps.DeploymentUpdate.json
@@ -10,14 +10,12 @@
       "endpoint": "/deployment/from",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "Id of the deployment to update from"
     },
     {
       "endpoint": "/deployment/to",
       "type": "string",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 31556952,
       "description": "Id of the deployment to update to"
     }
   ]

--- a/io.edgehog.devicemanager.fileTransfer.DeviceToServer.json
+++ b/io.edgehog.devicemanager.fileTransfer.DeviceToServer.json
@@ -13,7 +13,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Transfer ID for the file"
     },
     {
@@ -21,7 +20,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "The URL to upload the file to"
     },
     {
@@ -29,7 +27,6 @@
       "type": "stringarray",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Keys for the HTTP headers, must be in the order of the values"
     },
     {
@@ -37,7 +34,6 @@
       "type": "stringarray",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Values for the HTTP headers, must be in the order of the keys"
     },
     {
@@ -45,7 +41,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Encoding of the file or directory to upload",
       "doc": "Optional enum string for the file encoding with default value empty, other values are: [gz, lz4, tar, tar.gz, tar.lz4]"
     },
@@ -54,7 +49,6 @@
       "type": "boolean",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Flag to enable the progress reporting of the download."
     },
     {
@@ -62,7 +56,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Source from which the file should be read from.",
       "doc": "String enum specifying the source type, with allowed values: [storage, streaming, filesystem]."
     },
@@ -71,7 +64,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Source-specific information on what to upload to the server for the source.",
       "doc": "The value depends on the selected source type: for 'storage' is the ID of an 'io.edgehog.devicemanager.storage.File' property, for 'streaming' it's an empty string, and for 'filesystem' is a path of a file on the device."
     }

--- a/io.edgehog.devicemanager.fileTransfer.Response.json
+++ b/io.edgehog.devicemanager.fileTransfer.Response.json
@@ -13,7 +13,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Transfer ID for the file",
       "doc": "Can be either for download or upload transfers."
     },
@@ -22,7 +21,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Direction of the file transfer",
       "doc": "Specifies the direction of the transfer. Allowed values: 'server_to_device' or 'device_to_server'."
     },
@@ -31,7 +29,6 @@
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Success or error code for the transfer",
       "doc": "A 0 code is a success, errors are POSIX errno."
     },
@@ -40,7 +37,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Optional message for the response"
     }
   ]

--- a/io.edgehog.devicemanager.fileTransfer.ServerToDevice.json
+++ b/io.edgehog.devicemanager.fileTransfer.ServerToDevice.json
@@ -13,7 +13,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Transfer ID for the file",
       "doc": "If the file is to be stored, this MUST be unique to the file (e.g. hash of the content). For a file that needs to be streamed, it can be unique for the single request (e.g. uuid)."
     },
@@ -22,7 +21,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "The URL to get the file from"
     },
     {
@@ -30,7 +28,6 @@
       "type": "stringarray",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Keys for the HTTP headers, must be in the order of the values"
     },
     {
@@ -38,7 +35,6 @@
       "type": "stringarray",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Values for the HTTP headers, must be in the order of the keys"
     },
     {
@@ -46,7 +42,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Encoding of the file or directory to download",
       "doc": "Optional enum string for the file encoding with default value empty, other values are: [gz, lz4, tar, tar.gz, tar.lz4]"
     },
@@ -55,7 +50,6 @@
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "File size decompressed",
       "doc": "Total file size (if multiple files) uncompressed in bytes. It's used to reserve this space on the device."
     },
@@ -64,7 +58,6 @@
       "type": "boolean",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Flag to enable the progress reporting of the download."
     },
     {
@@ -72,7 +65,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Digest of the file contents",
       "doc": "Must be in the form sha256:deadbeaf, and should be used only if supported by the device."
     },
@@ -81,7 +73,6 @@
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "TTL on how long to keep the file for",
       "doc": "Optional ttl for how long to keep the file for, if 0 is forever"
     },
@@ -90,7 +81,6 @@
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Unix mode for the file",
       "doc": "Optional unix mode for the file, set to default if 0. All files are immutable, so setting it to writable has no effect."
     },
@@ -99,7 +89,6 @@
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Uid of the user owning the file",
       "doc": "Optional unix uid of the user owning the file, set to default if -1."
     },
@@ -108,7 +97,6 @@
       "type": "longinteger",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Gid of the user owning the file",
       "doc": "Optional unix gid of the group owning the file, set to default if -1."
     },
@@ -117,7 +105,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Destination where the file should be written to.",
       "doc": "String enum specifying the destination type, with allowed values: [storage, streaming, filesystem]."
     },
@@ -126,7 +113,6 @@
       "type": "string",
       "reliability": "guaranteed",
       "database_retention_policy": "use_ttl",
-      "database_retention_ttl": 3600,
       "description": "Destination-specific information on where to write the file to.",
       "doc": "The value depends on the selected destination type: for 'storage' and 'streaming' it's an empty string, and for 'filesystem' is a path to a file on the device."
     }


### PR DESCRIPTION
We used a 1yr policy for database retention as default. This was a problem on some clusters, where the default database retention policy is lower. Let astarte decide how to set the maximum database retention ttl.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
