### PR TITLE
feat(storage): create the request to delete a file

### DIFF
--- a/io.edgehog.devicemanager.storage.DeleteFile.json
+++ b/io.edgehog.devicemanager.storage.DeleteFile.json
@@ -1,0 +1,30 @@
+{
+  "interface_name": "io.edgehog.devicemanager.storage.DeleteFile",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "aggregation": "object",
+  "ownership": "server",
+  "description": "Delete a file stored on a device",
+  "doc": "Requests the deletion of a file stored on the device. The file must be one published through the `io.edgehog.devicemanager.storage.File` interface.",
+  "mappings": [
+    {
+      "endpoint": "/request/id",
+      "type": "string",
+      "description": "Id of the delete request",
+      "doc": "Id of a request on which we will be used to send the `io.edgehog.devicemanager.storage.Response`."
+    },
+    {
+      "endpoint": "/request/fileId",
+      "type": "string",
+      "description": "ID of the file to delete",
+      "doc": "Id of a file on the device published through the `io.edgehog.devicemanager.storage.File` interface."
+    },
+    {
+      "endpoint": "/request/force",
+      "type": "boolean",
+      "description": "Force the deletion of the file.",
+      "doc": "Force the deletion of the file even if it's currently in use, this could cause errors. Default to false."
+    }
+  ]
+}

--- a/io.edgehog.devicemanager.storage.Response.json
+++ b/io.edgehog.devicemanager.storage.Response.json
@@ -1,0 +1,46 @@
+{
+  "interface_name": "io.edgehog.devicemanager.storage.Response",
+  "version_major": 0,
+  "version_minor": 1,
+  "type": "datastream",
+  "ownership": "device",
+  "aggregation": "object",
+  "description": "Response for a storage operation",
+  "doc": "Used by the device to report the storage operation status upon completion.",
+  "mappings": [
+    {
+      "endpoint": "/request/id",
+      "type": "string",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Operation ID associated with the response"
+    },
+    {
+      "endpoint": "/request/type",
+      "type": "string",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Type of storage response",
+      "doc": "Specifies the direction of the transfer. Allowed values: 'delete'."
+    },
+    {
+      "endpoint": "/request/code",
+      "type": "longinteger",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Success or error code for the transfer",
+      "doc": "A 0 code is a success, errors are POSIX errno."
+    },
+    {
+      "endpoint": "/request/messages",
+      "type": "stringarray",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Optional messages for the response"
+    }
+  ]
+}


### PR DESCRIPTION
We created two new interface to permit the deletion of a stored file:

- io.edgehog.devicemanager.storage.DeleteFile: request from Astarte to delete a file containing the ID of a stored file.
- io.edgehog.devicemanager.storage.Response: response from the device with success or eventually the error information.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
