### PR TITLE
refactor(StorageUsage): change parameter and add fields

### DIFF
--- a/io.edgehog.devicemanager.StorageUsage.json
+++ b/io.edgehog.devicemanager.StorageUsage.json
@@ -1,13 +1,45 @@
 {
   "interface_name": "io.edgehog.devicemanager.StorageUsage",
-  "version_major": 0,
-  "version_minor": 1,
+  "version_major": 1,
+  "version_minor": 0,
   "type": "datastream",
   "ownership": "device",
   "aggregation": "object",
   "mappings": [
     {
-      "endpoint": "/%{label}/totalBytes",
+      "endpoint": "/%{storageId}/mounts",
+      "type": "stringarray",
+      "explicit_timestamp": true,
+      "description": "Optional path mounted on the device",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/%{storageId}/name",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Optional name of the storage",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/%{storageId}/fstype",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Optional filesystem of the storage",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/%{storageId}/kind",
+      "type": "string",
+      "explicit_timestamp": true,
+      "description": "Optional kind of storage",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 5184000
+    },
+    {
+      "endpoint": "/%{storageId}/totalBytes",
       "type": "longinteger",
       "explicit_timestamp": true,
       "description": "Total storage size in bytes",
@@ -15,7 +47,7 @@
       "database_retention_ttl": 5184000
     },
     {
-      "endpoint": "/%{label}/freeBytes",
+      "endpoint": "/%{storageId}/freeBytes",
       "type": "longinteger",
       "explicit_timestamp": true,
       "description": "Available storage bytes",


### PR DESCRIPTION
Change the endpoint parameter from label to deviceId, since before if the disk didn't have a label we would use the name, which will lead to problems for disk with multiple path levels (for example LVM disks like `/dev/mapper/linux-root`). Now we standardize the parameter using the disk id (or partition id), and add the optional fields of the path on device and label.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
