### PR TITLE
feat(fileTransfer): implement pre and post request hooks

### DIFF
--- a/io.edgehog.devicemanager.fileTransfer.DeviceToServer.json
+++ b/io.edgehog.devicemanager.fileTransfer.DeviceToServer.json
@@ -1,7 +1,7 @@
 {
   "interface_name": "io.edgehog.devicemanager.fileTransfer.DeviceToServer",
   "version_major": 0,
-  "version_minor": 1,
+  "version_minor": 2,
   "type": "datastream",
   "ownership": "server",
   "aggregation": "object",
@@ -74,6 +74,24 @@
       "database_retention_ttl": 3600,
       "description": "Source-specific information on what to upload to the server for the source.",
       "doc": "The value depends on the selected source type: for 'storage' is the ID of an 'io.edgehog.devicemanager.storage.File' property, for 'streaming' it's an empty string, and for 'filesystem' is a path of a file on the device."
+    },
+    {
+      "endpoint": "/request/preHook",
+      "type": "stringarray",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Pre request hook",
+      "doc": "Commands to execute before the file is requested. The command must succeed (e.g. exit code 0 on unix platforms) or the file transfer request will error. The following environment variables will be exported: $FT_REQUEST_ID as the file transfer request id, $FT_REQUEST_TARGET_TYPE as a value for the source type, $FT_REQUEST_TARGET as optional a value of the source, and $FT_REQUEST_PATH for the absolute path of the file"
+    },
+    {
+      "endpoint": "/request/postHook",
+      "type": "stringarray",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Post request hook",
+      "doc": "Commands to execute asfter the file is requested. The command must succeed (e.g. exit code 0 on unix platforms) or the file transfer request will error. The following environment variables will be exported: $FT_REQUEST_ID as the file transfer request id, $FT_REQUEST_TARGET_TYPE as a value for the source type, $FT_REQUEST_TARGET as optional a value of the source, and $FT_REQUEST_PATH for the absolute path of the file"
     }
   ]
 }

--- a/io.edgehog.devicemanager.fileTransfer.ServerToDevice.json
+++ b/io.edgehog.devicemanager.fileTransfer.ServerToDevice.json
@@ -1,7 +1,7 @@
 {
   "interface_name": "io.edgehog.devicemanager.fileTransfer.ServerToDevice",
   "version_major": 0,
-  "version_minor": 1,
+  "version_minor": 2,
   "type": "datastream",
   "ownership": "server",
   "aggregation": "object",
@@ -129,6 +129,24 @@
       "database_retention_ttl": 3600,
       "description": "Destination-specific information on where to write the file to.",
       "doc": "The value depends on the selected destination type: for 'storage' and 'streaming' it's an empty string, and for 'filesystem' is a path to a file on the device."
+    },
+    {
+      "endpoint": "/request/preHook",
+      "type": "stringarray",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Pre request hook",
+      "doc": "Commands to execute before the file is requested. The command must succeed (e.g. exit code 0 on unix platforms) or the file transfer request will error. The following environment variables will be exported: $FT_REQUEST_ID as the file transfer request id, $FT_REQUEST_TARGET_TYPE as a value for the destination type, $FT_REQUEST_TARGET as optional a value of the destination, and $FT_REQUEST_PATH for the absolute path of the file"
+    },
+    {
+      "endpoint": "/request/postHook",
+      "type": "stringarray",
+      "reliability": "guaranteed",
+      "database_retention_policy": "use_ttl",
+      "database_retention_ttl": 3600,
+      "description": "Post request hook",
+      "doc": "Commands to execute asfter the file is requested. The command must succeed (e.g. exit code 0 on unix platforms) or the file transfer request will error. The following environment variables will be exported: $FT_REQUEST_ID as the file transfer request id, $FT_REQUEST_TARGET_TYPE as a value for the destination type, $FT_REQUEST_TARGET as optional a value of the destination, and $FT_REQUEST_PATH for the absolute path of the file"
     }
   ]
 }


### PR DESCRIPTION
This will make it possibile to customize how a file transfer request is handled on a device. You can run a command to import the downloaded file or execute on it.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
